### PR TITLE
Upgrade RSMQ to 0.11.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,10 @@ class RedisSMQPromise {
         return Promise.promisify(this.rsmq.listQueues);
     };
 
+    get changeMessageVisibility() {
+        return Promise.promisify(this.rsmq.changeMessageVisibility);
+    };
+
     get createQueue() {
         return Promise.promisify(this.rsmq.createQueue);
     };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "bluebird": "^3.5.3",
-    "rsmq": "^0.9.3"
+    "rsmq": "^0.11.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
- Support changeMessageVisibility
- No break changes between rsmq 0.9.x and 0.11.x